### PR TITLE
Move projectRoot to config and fix readSourceFiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ export default defineConfig({
   })],
 });
 ```
+### projectRoot
+
+A string. Project root directory. Can be an absolute path, or a path relative to the current working directory.
+Defaults to '.'
 
 ### exclude
 

--- a/src/dead-file.ts
+++ b/src/dead-file.ts
@@ -98,7 +98,7 @@ export default function vitePluginDeadFile(
         `All source files: ${sourceFiles.size}`,
         `Used source files: ${touchedFiles.size}`,
         `Unused source files: ${deadFiles.size}`,
-        ...[...deadFiles].map((fullPath) => `  .${fullPath.substring(projectRoot.length)}`),
+        ...[...deadFiles].map((fullPath) => `  /${fullPath.substring(projectRoot.length)}`),
       ];
       if (typeof output === 'string' && isSafeFileName(output)) {
         const outputFile = resolve(projectRoot, output);

--- a/src/dead-file.ts
+++ b/src/dead-file.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import type { Plugin } from 'vite';
 
 export interface DeadFilePluginConfig {
+  projectRoot?: string;
   exclude?: string[];
   include?: string[];
   output?: string;
@@ -55,8 +56,7 @@ async function readSourceFiles(root: string, includeFiles: string[] = [], exclud
 }
 
 export default function vitePluginDeadFile(
-  projectRoot: string,
-  { include = [], exclude = [], output }: DeadFilePluginConfig = {}
+  { projectRoot = '.', include = [], exclude = [], output }: DeadFilePluginConfig = {}
 ): Plugin {
   let doAnalysis = false;
   let touchedFiles: Set<string>;

--- a/src/dead-file.ts
+++ b/src/dead-file.ts
@@ -37,15 +37,15 @@ async function readSourceFiles(root: string, includeFiles: string[] = [], exclud
   const level1Sources = await fs.readdir(root);
   const readAll = level1Sources.filter(isLegalSource).map(async (fileName) => {
     const subFileName = resolve(root, fileName);
-    if (includeFiles.length > 0 && !includeFiles.includes(subFileName)) {
+    if (includeFiles.length > 0 && !includeFiles.some(includeFile => subFileName.startsWith(includeFile))) {
       return;
     }
-    if (excludeFiles.includes(subFileName)) {
+    if (excludeFiles.some(excludeFile => subFileName.startsWith(excludeFile))) {
       return;
     }
     const fileStat = await fs.stat(subFileName);
     if (fileStat.isDirectory()) {
-      const subResult = await readSourceFiles(subFileName);
+      const subResult = await readSourceFiles(subFileName, includeFiles, excludeFiles);
       result = [...result, ...subResult];
     } else if (fileStat.isFile()) {
       result.push(subFileName);

--- a/src/dead-file.ts
+++ b/src/dead-file.ts
@@ -98,7 +98,7 @@ export default function vitePluginDeadFile(
         `All source files: ${sourceFiles.size}`,
         `Used source files: ${touchedFiles.size}`,
         `Unused source files: ${deadFiles.size}`,
-        ...[...deadFiles].map((fullPath) => `  /${fullPath.substring(projectRoot.length)}`),
+        ...[...deadFiles].map((fullPath) => `  .${fullPath.substring(resolve(projectRoot).length)}`),
       ];
       if (typeof output === 'string' && isSafeFileName(output)) {
         const outputFile = resolve(projectRoot, output);

--- a/src/dead-file.ts
+++ b/src/dead-file.ts
@@ -36,7 +36,7 @@ async function readSourceFiles(root: string, includeFiles: string[] = [], exclud
   let result: string[] = [];
   const level1Sources = await fs.readdir(root);
   const readAll = level1Sources.filter(isLegalSource).map(async (fileName) => {
-    const subFileName = `${root}/${fileName}`;
+    const subFileName = resolve(root, fileName);
     if (includeFiles.length > 0 && !includeFiles.includes(subFileName)) {
       return;
     }


### PR DESCRIPTION
- `projectRoot` was mandatory as a first argument to deadFile plugin function (but not explained in documentation).
I added it to configuration instead with default value to `.`

- In `readSourceFiles` function, the test to see if `subFileName` is included in `includeFiles` was always `false`, due to `includeFiles` being an array of full path but `subFileName` constructed with a concatenation of `root` and `fileName`.
Fixed it by transforming `subFileName` to full path.

- Added some documentation for `projectRoot`. See above.