### PR TITLE
 fix #16, a falsely safe dir check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.2.3](https://github.com/stauren/vite-plugin-deadfile/tree/v1.2.3) (2024-04-09)
+- fix https://github.com/stauren/vite-plugin-deadfile/issues/16, an error message falsely popup when the outputDir is the root dir, better win path format support
+- change the plugin name to be more traceable
+- refactor logger a bit
+
 ## [1.2.2](https://github.com/stauren/vite-plugin-deadfile/tree/v1.2.2) (2024-04-07)
 - Fix a bug that an illegal import will break the plugin (import a subpath not specified in exports field of package.json)
 - Fix a bug that dynamic import is not detected when it's not wrapped in an arrow function

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-deadfile",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "MIT",
   "author": "stauren@qq.com",
   "type": "module",

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,4 +1,45 @@
-export function log(...contents: unknown[]) {
+import { promises as fs } from 'node:fs';
+import { relative } from 'node:path';
+
+const PLUGIN_NAME = 'vite-plugin-deadfile';
+
+const innerLogger = (...contents: unknown[]) => {
   // biome-ignore lint/suspicious/noConsoleLog: is's a logger
-  console.log('[vite-plugin-deadfile] ', ...contents);
+  console.log(...contents);
+};
+
+async function delay(timeout: number) {
+  return new Promise((resolve) => setTimeout(resolve, timeout));
+}
+
+export function log(...contents: unknown[]) {
+  innerLogger(`\n[${PLUGIN_NAME}]: `, ...contents);
+}
+
+export async function outputLog(contents: string[], outputFile?: string) {
+  const formattedContents = contents.reduce(
+    (last, current) => {
+      last.push(`  ${current}`);
+      return last;
+    },
+    [`[${PLUGIN_NAME}]:`],
+  );
+
+  if (outputFile) {
+    await fs.writeFile(outputFile, formattedContents.join('\n'));
+    innerLogger(
+      `[${PLUGIN_NAME}]: `,
+      `Unused source file entries write to: ${relative(
+        process.cwd(),
+        outputFile,
+      )}`,
+    );
+  } else {
+    // avoid logs mess up as: transforming (23) node_modules/.../dist/reactivity.[vite-plugin-deadfile]:
+    await delay(1);
+
+    for (const line of formattedContents) {
+      innerLogger(line);
+    }
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
+import { sep } from 'node:path';
+
 const REG_POSTFIX = /[?#].*$/s;
 const REG_SAFE_FILE_NAME = /^[a-zA-Z0-9._-]+$/;
-const REG_SAFE_PATH = /^(\.\/|\/)?([a-zA-Z0-9._-]+\/)+$/;
+const REG_SAFE_POSIX_PATH = /^(\.\/|\/)?([a-zA-Z0-9._-]+\/)+$/;
+// only support relative path for win
+const REG_SAFE_WIN_PATH = /^(\.\\)?([a-zA-Z0-9._-]+\\)+$/;
 
 export function cleanUrl(url: string): string {
   return url.replace(REG_POSTFIX, '');
@@ -11,16 +15,18 @@ export function isSafeFileName(name: string) {
 }
 
 export function withTrailingSlash(path: string): string {
-  if (path[path.length - 1] !== '/') {
-    return `${path}/`;
+  if (path[path.length - 1] !== sep) {
+    return `${path}${sep}`;
   }
   return path;
 }
 
 export function isSafePath(name: string) {
-  return withTrailingSlash(name).match(REG_SAFE_PATH);
+  return withTrailingSlash(name).match(
+    sep === '/' ? REG_SAFE_POSIX_PATH : REG_SAFE_WIN_PATH,
+  );
 }
 
 export function isParentDir(parent: string, file: string) {
-  return file.startsWith(withTrailingSlash(parent));
+  return withTrailingSlash(file).startsWith(withTrailingSlash(parent));
 }


### PR DESCRIPTION
- fix #16, an error message falsely popup when the outputDir is the root dir, better win path format support
- change the plugin name to be more traceable
- refactor logger a bit